### PR TITLE
feat: add ACP/TUI session support with v1/v2 version markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for TUI/ACP sessions stored at `~/.kiro/sessions/cli/` (created via `kiro-cli acp` or JetBrains/Zed editor integrations)
 - ACP sessions appear merged with legacy sessions in `ksm list`, sorted by last activity
-- `[t]` column marker distinguishes TUI/ACP sessions from legacy chat sessions
+- `v1`/`v2` column marker on every session: `v1` for legacy chat sessions, `v2` for ACP/editor sessions
 - All commands (delete, resume, name, tag, untag, archive, index, search, chain detection) work on ACP sessions
 
 ## [0.2.7] - 2026-04-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for TUI/ACP sessions stored at `~/.kiro/sessions/cli/` (created via `kiro-cli acp` or JetBrains/Zed editor integrations)
+- ACP sessions appear merged with legacy sessions in `ksm list`, sorted by last activity
+- `[t]` column marker distinguishes TUI/ACP sessions from legacy chat sessions
+- All commands (delete, resume, name, tag, untag, archive, index, search, chain detection) work on ACP sessions
+
 ## [0.2.7] - 2026-04-01
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,15 +32,15 @@ ksm list
 Output:
 
 ```
-[0]        [t]  Project Planning                           2m    10 msgs   work, urgent
-[1]   [i]       API Integration Research                  15m    35 msgs   research
-[2]             Quick question about Rust                  1h     5 msgs
+[0]        v2  Project Planning                           2m    10 msgs   work, urgent
+[1]   [i]  v1  API Integration Research                  15m    35 msgs   research
+[2]        v1  Quick question about Rust                  1h     5 msgs
 ```
 
 Each line shows:
 - Index number (used by other commands)
 - `[i]` marker if session is indexed (searchable)
-- `[t]` marker if session is a TUI/ACP session (created via `kiro-cli acp` or an editor integration like JetBrains or Zed)
+- `v1` or `v2` version marker (`v1` = legacy chat session, `v2` = ACP/editor session)
 - Session name or first message preview
 - Time since last activity (compact format: s, m, h, d, w)
 - Message count
@@ -48,7 +48,7 @@ Each line shows:
 
 ### TUI/ACP Sessions
 
-Sessions created through editor integrations (JetBrains, Zed) or `kiro-cli acp` are stored as file pairs at `~/.kiro/sessions/cli/` rather than in kiro-cli's SQLite database. These sessions are shown with a `[t]` marker and support all the same commands as regular sessions: delete, resume, name, tag, archive, index, and search.
+Sessions created through editor integrations (JetBrains, Zed) or `kiro-cli acp` are stored as file pairs at `~/.kiro/sessions/cli/` rather than in kiro-cli's SQLite database. These sessions are shown with a `v2` marker and support all the same commands as regular sessions: delete, resume, name, tag, archive, index, and search.
 
 ### Show Full Parent Chain
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -32,18 +32,23 @@ ksm list
 Output:
 
 ```
-[0]        Project Planning                           2m    10 msgs   work, urgent
-[1]   [i]  API Integration Research                  15m    35 msgs   research
-[2]        Quick question about Rust                  1h     5 msgs
+[0]        [t]  Project Planning                           2m    10 msgs   work, urgent
+[1]   [i]       API Integration Research                  15m    35 msgs   research
+[2]             Quick question about Rust                  1h     5 msgs
 ```
 
 Each line shows:
 - Index number (used by other commands)
 - `[i]` marker if session is indexed (searchable)
+- `[t]` marker if session is a TUI/ACP session (created via `kiro-cli acp` or an editor integration like JetBrains or Zed)
 - Session name or first message preview
 - Time since last activity (compact format: s, m, h, d, w)
 - Message count
 - Tags (displayed comma-separated; use spaces to separate when adding tags)
+
+### TUI/ACP Sessions
+
+Sessions created through editor integrations (JetBrains, Zed) or `kiro-cli acp` are stored as file pairs at `~/.kiro/sessions/cli/` rather than in kiro-cli's SQLite database. These sessions are shown with a `[t]` marker and support all the same commands as regular sessions: delete, resume, name, tag, archive, index, and search.
 
 ### Show Full Parent Chain
 

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -5,7 +5,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::cli::pager;
 use crate::cli::styles;
-use crate::models::{Archive, Chunk, SearchResult, Session, SessionMetadata};
+use crate::models::{Archive, Chunk, SearchResult, Session, SessionMetadata, SourceType};
 
 /// Format a millisecond timestamp as compact relative time.
 ///
@@ -172,8 +172,8 @@ fn get_parent_index(
 /// Print the session list with new column-aligned format.
 ///
 /// Format:
-/// [0]  [i]  Session name here...              2s ago     9 msgs   tag1, tag2
-/// [1]       Another session                  14m ago   104 msgs   
+/// [0]  [i]  [t]  Session name here...              2s ago     9 msgs   tag1, tag2
+/// [1]            Another session                  14m ago   104 msgs   
 pub fn print_session_list(
     sessions: &[Session],
     metadata: &HashMap<String, SessionMetadata>,
@@ -194,7 +194,7 @@ pub fn print_session_list(
     let idx_width = format!("[{}]", max_idx).len();
 
     // Dynamic name width based on terminal width
-    // Fixed columns: indexed marker (5) + spacing (2) + TIME_WIDTH (8) + spacing (2) + MSG_WIDTH (9) + spacing (2) = 28
+    // Fixed columns: indexed marker (5) + source marker (5) + spacing (2) + TIME_WIDTH (8) + spacing (2) + MSG_WIDTH (9) + spacing (2) = 33
     let term_width = pager::terminal_size().map(|(w, _)| w);
 
     // Find the longest tag display width across all visible sessions
@@ -215,15 +215,19 @@ pub fn print_session_list(
     let name_width = term_width
         .map(|w| {
             w.saturating_sub(idx_width)
-                .saturating_sub(28)
+                .saturating_sub(33)
                 .saturating_sub(max_tag_width)
                 .clamp(20, 80)
         })
         .unwrap_or(35);
-    // Width of a line without tags: idx + indexed(5) + spacing(2) + name + spacing(2) + time(8) + spacing(2) + msgs(9)
-    let base_line_width = idx_width + 5 + 2 + name_width + 2 + TIME_WIDTH + 2 + MSG_WIDTH;
+    // Width of a line without tags: idx + indexed(5) + source(5) + spacing(2) + name + spacing(2) + time(8) + spacing(2) + msgs(9)
+    let base_line_width = idx_width + 5 + 5 + 2 + name_width + 2 + TIME_WIDTH + 2 + MSG_WIDTH;
     // Indent for wrapped tags: align to name column
-    let tag_indent = idx_width + 5 + 2;
+    let tag_indent = idx_width + 5 + 5 + 2;
+
+    let has_acp = visible_indices
+        .iter()
+        .any(|&idx| sessions[idx].source_type == SourceType::Acp);
 
     println!();
     for &idx in visible_indices {
@@ -285,6 +289,11 @@ pub fn print_session_list(
         } else {
             "     ".to_string()
         };
+        let source_str = if session.source_type == SourceType::Acp {
+            format!("  {}", styles::tui_marker())
+        } else {
+            "     ".to_string()
+        };
 
         let tags_str = if tags.is_empty() {
             String::new()
@@ -305,9 +314,10 @@ pub fn print_session_list(
         if !tags.is_empty() && would_overflow {
             // Print session without tags, then tags on next line
             println!(
-                "{}{}  {}  {}  {}",
+                "{}{}{}  {}  {}  {}",
                 idx_padded,
                 indexed_str,
+                source_str,
                 name_padded,
                 styles::time(&time_padded),
                 styles::msg_count(&msg_padded),
@@ -315,9 +325,10 @@ pub fn print_session_list(
             println!("{}{}", " ".repeat(tag_indent), styles::tags(&tags),);
         } else {
             println!(
-                "{}{}  {}  {}  {}{}",
+                "{}{}{}  {}  {}  {}{}",
                 idx_padded,
                 indexed_str,
+                source_str,
                 name_padded,
                 styles::time(&time_padded),
                 styles::msg_count(&msg_padded),
@@ -356,15 +367,24 @@ pub fn print_session_list(
     }
 
     // Legend
-    if indexed_session_ids
+    let has_indexed = indexed_session_ids
         .iter()
-        .any(|id| visible_indices.iter().any(|&idx| &sessions[idx].id == id))
-    {
+        .any(|id| visible_indices.iter().any(|&idx| &sessions[idx].id == id));
+
+    if has_indexed || has_acp {
         println!();
-        println!(
-            "{}",
-            styles::legend("[i] = indexed (searchable via ksm search)")
-        );
+        if has_indexed {
+            println!(
+                "{}",
+                styles::legend("[i] = indexed (searchable via ksm search)")
+            );
+        }
+        if has_acp {
+            println!(
+                "{}",
+                styles::legend("[t] = TUI/ACP session (from ~/.kiro/sessions/cli/)")
+            );
+        }
     }
 }
 

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -172,8 +172,8 @@ fn get_parent_index(
 /// Print the session list with new column-aligned format.
 ///
 /// Format:
-/// [0]  [i]  [t]  Session name here...              2s ago     9 msgs   tag1, tag2
-/// [1]            Another session                  14m ago   104 msgs   
+/// [0]  [i]  v2  Session name here...              2s ago     9 msgs   tag1, tag2
+/// [1]       v1  Another session                  14m ago   104 msgs   
 pub fn print_session_list(
     sessions: &[Session],
     metadata: &HashMap<String, SessionMetadata>,
@@ -194,7 +194,7 @@ pub fn print_session_list(
     let idx_width = format!("[{}]", max_idx).len();
 
     // Dynamic name width based on terminal width
-    // Fixed columns: indexed marker (5) + source marker (5) + spacing (2) + TIME_WIDTH (8) + spacing (2) + MSG_WIDTH (9) + spacing (2) = 33
+    // Fixed columns: indexed marker (5) + source marker (6) + spacing (2) + TIME_WIDTH (8) + spacing (2) + MSG_WIDTH (9) + spacing (2) = 34
     let term_width = pager::terminal_size().map(|(w, _)| w);
 
     // Find the longest tag display width across all visible sessions
@@ -215,19 +215,15 @@ pub fn print_session_list(
     let name_width = term_width
         .map(|w| {
             w.saturating_sub(idx_width)
-                .saturating_sub(33)
+                .saturating_sub(34)
                 .saturating_sub(max_tag_width)
                 .clamp(20, 80)
         })
         .unwrap_or(35);
-    // Width of a line without tags: idx + indexed(5) + source(5) + spacing(2) + name + spacing(2) + time(8) + spacing(2) + msgs(9)
-    let base_line_width = idx_width + 5 + 5 + 2 + name_width + 2 + TIME_WIDTH + 2 + MSG_WIDTH;
+    // Width of a line without tags: idx + indexed(5) + source(6) + spacing(2) + name + spacing(2) + time(8) + spacing(2) + msgs(9)
+    let base_line_width = idx_width + 5 + 6 + 2 + name_width + 2 + TIME_WIDTH + 2 + MSG_WIDTH;
     // Indent for wrapped tags: align to name column
-    let tag_indent = idx_width + 5 + 5 + 2;
-
-    let has_acp = visible_indices
-        .iter()
-        .any(|&idx| sessions[idx].source_type == SourceType::Acp);
+    let tag_indent = idx_width + 5 + 6 + 2;
 
     println!();
     for &idx in visible_indices {
@@ -290,9 +286,9 @@ pub fn print_session_list(
             "     ".to_string()
         };
         let source_str = if session.source_type == SourceType::Acp {
-            format!("  {}", styles::tui_marker())
+            format!("  {}", styles::version_marker("v2"))
         } else {
-            "     ".to_string()
+            format!("  {}", styles::version_marker("v1"))
         };
 
         let tags_str = if tags.is_empty() {
@@ -371,20 +367,12 @@ pub fn print_session_list(
         .iter()
         .any(|id| visible_indices.iter().any(|&idx| &sessions[idx].id == id));
 
-    if has_indexed || has_acp {
+    if has_indexed {
         println!();
-        if has_indexed {
-            println!(
-                "{}",
-                styles::legend("[i] = indexed (searchable via ksm search)")
-            );
-        }
-        if has_acp {
-            println!(
-                "{}",
-                styles::legend("[t] = TUI/ACP session (from ~/.kiro/sessions/cli/)")
-            );
-        }
+        println!(
+            "{}",
+            styles::legend("[i] = indexed (searchable via ksm search)")
+        );
     }
 }
 

--- a/src/cli/styles.rs
+++ b/src/cli/styles.rs
@@ -26,6 +26,11 @@ pub fn indexed_marker() -> String {
     format!("{}[i]{}", ansi::GREEN, ansi::RESET)
 }
 
+/// Format TUI/ACP source marker: cyan `[t]`
+pub fn tui_marker() -> String {
+    format!("{}[t]{}", ansi::CYAN, ansi::RESET)
+}
+
 /// Format session/archive name: plain white
 pub fn name(s: &str) -> String {
     s.to_string()

--- a/src/cli/styles.rs
+++ b/src/cli/styles.rs
@@ -26,9 +26,9 @@ pub fn indexed_marker() -> String {
     format!("{}[i]{}", ansi::GREEN, ansi::RESET)
 }
 
-/// Format TUI/ACP source marker: cyan `[t]`
-pub fn tui_marker() -> String {
-    format!("{}[t]{}", ansi::CYAN, ansi::RESET)
+/// Format version marker: cyan `v1` or `v2`
+pub fn version_marker(v: &str) -> String {
+    format!("{}{}{}", ansi::CYAN, v, ansi::RESET)
 }
 
 /// Format session/archive name: plain white

--- a/src/data/acp.rs
+++ b/src/data/acp.rs
@@ -1,0 +1,397 @@
+//! Session source backed by ACP/TUI file pairs at ~/.kiro/sessions/cli/.
+//!
+//! Each session is stored as:
+//!   <session-id>.json  - metadata (session_id, cwd, created_at, updated_at, title)
+//!   <session-id>.jsonl - event log (Prompt, AssistantMessage, ToolResults lines)
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::data::SessionSource;
+use crate::error::{KsmError, Result};
+use crate::models::{
+    AssistantContent, ConversationData, HistoryEntry, PromptContent, ResponseContent, Session,
+    SourceType, UserContent, UserMessage,
+};
+
+pub struct AcpSource {
+    sessions_dir: PathBuf,
+}
+
+impl Default for AcpSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AcpSource {
+    pub fn new() -> Self {
+        let home = std::env::var("HOME").unwrap_or_default();
+        AcpSource {
+            sessions_dir: PathBuf::from(home).join(".kiro/sessions/cli"),
+        }
+    }
+
+    fn json_path(&self, session_id: &str) -> PathBuf {
+        self.sessions_dir.join(format!("{}.json", session_id))
+    }
+
+    fn jsonl_path(&self, session_id: &str) -> PathBuf {
+        self.sessions_dir.join(format!("{}.jsonl", session_id))
+    }
+
+    /// Read and parse the .json metadata file for a session.
+    fn read_meta(&self, session_id: &str) -> Result<AcpMeta> {
+        let path = self.json_path(session_id);
+        let content = std::fs::read_to_string(&path)
+            .map_err(|_| KsmError::SessionNotFound(session_id.to_string()))?;
+        serde_json::from_str(&content)
+            .map_err(|e| KsmError::Database(format!("Failed to parse ACP meta {}: {}", session_id, e)))
+    }
+
+    /// List all session IDs whose .json files exist in the sessions dir.
+    fn all_ids(&self) -> Vec<String> {
+        let Ok(entries) = std::fs::read_dir(&self.sessions_dir) else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| {
+                let name = e.file_name().into_string().ok()?;
+                name.strip_suffix(".json").map(|s| s.to_string())
+            })
+            .collect()
+    }
+}
+
+// --- Serde types for .json metadata ---
+
+#[derive(Deserialize)]
+struct AcpMeta {
+    session_id: String,
+    cwd: String,
+    created_at: String, // ISO 8601
+    updated_at: String, // ISO 8601
+    #[serde(default)]
+    title: Option<String>,
+}
+
+// --- Serde types for .jsonl events ---
+
+#[derive(Deserialize)]
+struct AcpEvent {
+    kind: String,
+    data: serde_json::Value,
+}
+
+/// Parse ISO 8601 timestamp to milliseconds since epoch.
+fn iso_to_ms(s: &str) -> i64 {
+    // Use a simple manual parse to avoid adding a chrono dependency.
+    // Format: "2026-03-22T05:59:41.761090399Z"
+    // We parse up to seconds precision and ignore sub-seconds.
+    let s = s.trim_end_matches('Z');
+    // Split on T
+    let (date_part, time_part) = match s.split_once('T') {
+        Some(p) => p,
+        None => return 0,
+    };
+    let date_parts: Vec<&str> = date_part.split('-').collect();
+    let time_parts: Vec<&str> = time_part.split(':').collect();
+    if date_parts.len() < 3 || time_parts.len() < 3 {
+        return 0;
+    }
+    let year: i64 = date_parts[0].parse().unwrap_or(0);
+    let month: i64 = date_parts[1].parse().unwrap_or(0);
+    let day: i64 = date_parts[2].parse().unwrap_or(0);
+    let hour: i64 = time_parts[0].parse().unwrap_or(0);
+    let min: i64 = time_parts[1].parse().unwrap_or(0);
+    let sec: i64 = time_parts[2]
+        .split('.')
+        .next()
+        .unwrap_or("0")
+        .parse()
+        .unwrap_or(0);
+
+    // Days since epoch using proleptic Gregorian calendar
+    let days = days_since_epoch(year, month, day);
+    let secs = days * 86400 + hour * 3600 + min * 60 + sec;
+    secs * 1000
+}
+
+fn days_since_epoch(year: i64, month: i64, day: i64) -> i64 {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let y = if month <= 2 { year - 1 } else { year };
+    let m = month as i64;
+    let d = day as i64;
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Parse the .jsonl event log into ConversationData.
+fn parse_jsonl(session_id: &str, content: &str) -> ConversationData {
+    let mut history = Vec::new();
+
+    let mut lines = content.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Ok(event) = serde_json::from_str::<AcpEvent>(line) else {
+            continue;
+        };
+        if event.kind != "Prompt" {
+            continue;
+        }
+        // Extract user text from Prompt event
+        let user_text = extract_text_content(&event.data);
+
+        // Collect the next AssistantMessage event (may be separated by ToolResults)
+        let mut assistant_text = String::new();
+        let mut message_id: Option<String> = None;
+
+        // Peek ahead through remaining lines for the next AssistantMessage
+        let remaining: Vec<&str> = lines.clone().collect();
+        for next_line in &remaining {
+            let Ok(next_event) = serde_json::from_str::<AcpEvent>(next_line) else {
+                continue;
+            };
+            if next_event.kind == "AssistantMessage" {
+                assistant_text = extract_text_content(&next_event.data);
+                message_id = next_event.data.get("message_id").and_then(|v| v.as_str()).map(|s| s.to_string());
+                break;
+            }
+            if next_event.kind == "Prompt" {
+                break; // Next user turn, stop
+            }
+        }
+
+        let user_msg = UserMessage {
+            content: Some(UserContent::Prompt(PromptContent { prompt: user_text })),
+            timestamp: None,
+        };
+        let assistant = Some(AssistantContent::Response(ResponseContent {
+            message_id,
+            content: assistant_text,
+        }));
+
+        history.push(HistoryEntry {
+            user: Some(user_msg),
+            assistant,
+            request_metadata: None,
+        });
+    }
+
+    ConversationData {
+        conversation_id: session_id.to_string(),
+        history,
+        latest_summary: None,
+    }
+}
+
+/// Extract concatenated text from ACP event data content array.
+fn extract_text_content(data: &serde_json::Value) -> String {
+    data.get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|item| item.get("kind").and_then(|k| k.as_str()) == Some("text"))
+                .filter_map(|item| item.get("data").and_then(|d| d.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default()
+}
+
+/// Extract preview from .jsonl: title if present, else first Prompt text.
+fn extract_preview(title: Option<&str>, jsonl_content: &str) -> String {
+    if let Some(t) = title {
+        if !t.is_empty() {
+            return t.to_string();
+        }
+    }
+    // Fall back to first Prompt text
+    for line in jsonl_content.lines() {
+        let Ok(event) = serde_json::from_str::<AcpEvent>(line) else {
+            continue;
+        };
+        if event.kind == "Prompt" {
+            let text = extract_text_content(&event.data);
+            if !text.is_empty() {
+                let sanitised: String = text
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .chars()
+                    .take(100)
+                    .collect();
+                return sanitised;
+            }
+        }
+    }
+    "[No preview available]".to_string()
+}
+
+/// Count Prompt events in .jsonl (= number of user turns = message pairs).
+fn count_messages(jsonl_content: &str) -> u32 {
+    jsonl_content
+        .lines()
+        .filter(|line| {
+            serde_json::from_str::<AcpEvent>(line)
+                .map(|e| e.kind == "Prompt")
+                .unwrap_or(false)
+        })
+        .count() as u32
+}
+
+/// Extract message IDs from AssistantMessage events in .jsonl.
+fn extract_message_ids_from_jsonl(jsonl_content: &str) -> Vec<String> {
+    jsonl_content
+        .lines()
+        .filter_map(|line| {
+            let event = serde_json::from_str::<AcpEvent>(line).ok()?;
+            if event.kind != "AssistantMessage" {
+                return None;
+            }
+            event.data.get("message_id")?.as_str().map(|s| s.to_string())
+        })
+        .collect()
+}
+
+impl SessionSource for AcpSource {
+    fn list_sessions(&self) -> Result<Vec<Session>> {
+        let current_dir = std::env::current_dir()?.display().to_string();
+        let mut sessions = Vec::new();
+
+        for id in self.all_ids() {
+            let Ok(meta) = self.read_meta(&id) else {
+                continue;
+            };
+            if meta.cwd != current_dir {
+                continue;
+            }
+            let jsonl_path = self.jsonl_path(&id);
+            let jsonl = std::fs::read_to_string(&jsonl_path).unwrap_or_default();
+            let preview = extract_preview(meta.title.as_deref(), &jsonl);
+            let msg_count = count_messages(&jsonl);
+
+            sessions.push(Session {
+                id: meta.session_id,
+                created_at: iso_to_ms(&meta.created_at),
+                updated_at: iso_to_ms(&meta.updated_at),
+                preview,
+                msg_count,
+                source_type: SourceType::Acp,
+            });
+        }
+
+        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(sessions)
+    }
+
+    fn list_session_updates(&self) -> Result<Vec<(String, i64)>> {
+        let current_dir = std::env::current_dir()?.display().to_string();
+        let mut updates = Vec::new();
+
+        for id in self.all_ids() {
+            let Ok(meta) = self.read_meta(&id) else {
+                continue;
+            };
+            if meta.cwd != current_dir {
+                continue;
+            }
+            updates.push((meta.session_id, iso_to_ms(&meta.updated_at)));
+        }
+
+        Ok(updates)
+    }
+
+    fn get_conversation(&self, session_id: &str) -> Result<ConversationData> {
+        let jsonl_path = self.jsonl_path(session_id);
+        let content = std::fs::read_to_string(&jsonl_path)
+            .map_err(|_| KsmError::SessionNotFound(session_id.to_string()))?;
+        Ok(parse_jsonl(session_id, &content))
+    }
+
+    fn get_conversation_with_created_at(&self, session_id: &str) -> Result<(ConversationData, i64)> {
+        let meta = self.read_meta(session_id)?;
+        let created_at = iso_to_ms(&meta.created_at);
+        let conv = self.get_conversation(session_id)?;
+        Ok((conv, created_at))
+    }
+
+    fn get_message_ids(&self, session_id: &str) -> Result<Vec<String>> {
+        let jsonl_path = self.jsonl_path(session_id);
+        let content = std::fs::read_to_string(&jsonl_path)
+            .map_err(|_| KsmError::SessionNotFound(session_id.to_string()))?;
+        Ok(extract_message_ids_from_jsonl(&content))
+    }
+
+    fn has_compact_tag(&self, _session_id: &str) -> Result<bool> {
+        Ok(false) // ACP sessions don't use the Compact tag mechanism
+    }
+
+    fn get_timestamps(&self, session_id: &str) -> Result<(i64, i64)> {
+        let meta = self.read_meta(session_id)?;
+        Ok((iso_to_ms(&meta.created_at), iso_to_ms(&meta.updated_at)))
+    }
+
+    fn update_timestamp(&self, session_id: &str, timestamp: i64) -> Result<()> {
+        let path = self.json_path(session_id);
+        let content = std::fs::read_to_string(&path)
+            .map_err(|_| KsmError::SessionNotFound(session_id.to_string()))?;
+        let mut value: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| KsmError::Database(format!("Failed to parse ACP meta: {}", e)))?;
+
+        // Convert ms back to ISO 8601
+        let secs = timestamp / 1000;
+        let ms = timestamp % 1000;
+        let iso = ms_to_iso(secs, ms);
+        value["updated_at"] = serde_json::Value::String(iso);
+
+        let updated = serde_json::to_string_pretty(&value)
+            .map_err(|e| KsmError::Database(format!("Failed to serialize ACP meta: {}", e)))?;
+        std::fs::write(&path, updated)?;
+        Ok(())
+    }
+
+    fn delete_session(&self, session_id: &str) -> Result<()> {
+        let json_path = self.json_path(session_id);
+        let jsonl_path = self.jsonl_path(session_id);
+        // Remove both files; ignore errors if already gone
+        let _ = std::fs::remove_file(&json_path);
+        let _ = std::fs::remove_file(&jsonl_path);
+        Ok(())
+    }
+
+    fn source_type(&self) -> SourceType {
+        SourceType::Acp
+    }
+}
+
+/// Convert Unix seconds + ms to ISO 8601 string (UTC).
+fn ms_to_iso(secs: i64, ms: i64) -> String {
+    // Reverse of days_since_epoch
+    let (year, month, day) = epoch_secs_to_ymd(secs);
+    let time_of_day = secs.rem_euclid(86400);
+    let h = time_of_day / 3600;
+    let m = (time_of_day % 3600) / 60;
+    let s = time_of_day % 60;
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}000000Z", year, month, day, h, m, s, ms)
+}
+
+fn epoch_secs_to_ymd(secs: i64) -> (i64, i64, i64) {
+    let days = secs.div_euclid(86400);
+    // Civil date from days since epoch (same algorithm, reversed)
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}

--- a/src/data/acp.rs
+++ b/src/data/acp.rs
@@ -46,8 +46,9 @@ impl AcpSource {
         let path = self.json_path(session_id);
         let content = std::fs::read_to_string(&path)
             .map_err(|_| KsmError::SessionNotFound(session_id.to_string()))?;
-        serde_json::from_str(&content)
-            .map_err(|e| KsmError::Database(format!("Failed to parse ACP meta {}: {}", session_id, e)))
+        serde_json::from_str(&content).map_err(|e| {
+            KsmError::Database(format!("Failed to parse ACP meta {}: {}", session_id, e))
+        })
     }
 
     /// List all session IDs whose .json files exist in the sessions dir.
@@ -122,8 +123,8 @@ fn iso_to_ms(s: &str) -> i64 {
 fn days_since_epoch(year: i64, month: i64, day: i64) -> i64 {
     // Algorithm from https://howardhinnant.github.io/date_algorithms.html
     let y = if month <= 2 { year - 1 } else { year };
-    let m = month as i64;
-    let d = day as i64;
+    let m = month;
+    let d = day;
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = y - era * 400;
     let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
@@ -158,7 +159,11 @@ fn parse_jsonl(session_id: &str, content: &str) -> ConversationData {
             };
             if next_event.kind == "AssistantMessage" {
                 assistant_text = extract_text_content(&next_event.data);
-                message_id = next_event.data.get("message_id").and_then(|v| v.as_str()).map(|s| s.to_string());
+                message_id = next_event
+                    .data
+                    .get("message_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
                 break;
             }
             if next_event.kind == "Prompt" {
@@ -205,10 +210,10 @@ fn extract_text_content(data: &serde_json::Value) -> String {
 
 /// Extract preview from .jsonl: title if present, else first Prompt text.
 fn extract_preview(title: Option<&str>, jsonl_content: &str) -> String {
-    if let Some(t) = title {
-        if !t.is_empty() {
-            return t.to_string();
-        }
+    if let Some(t) = title
+        && !t.is_empty()
+    {
+        return t.to_string();
     }
     // Fall back to first Prompt text
     for line in jsonl_content.lines() {
@@ -253,7 +258,11 @@ fn extract_message_ids_from_jsonl(jsonl_content: &str) -> Vec<String> {
             if event.kind != "AssistantMessage" {
                 return None;
             }
-            event.data.get("message_id")?.as_str().map(|s| s.to_string())
+            event
+                .data
+                .get("message_id")?
+                .as_str()
+                .map(|s| s.to_string())
         })
         .collect()
 }
@@ -313,7 +322,10 @@ impl SessionSource for AcpSource {
         Ok(parse_jsonl(session_id, &content))
     }
 
-    fn get_conversation_with_created_at(&self, session_id: &str) -> Result<(ConversationData, i64)> {
+    fn get_conversation_with_created_at(
+        &self,
+        session_id: &str,
+    ) -> Result<(ConversationData, i64)> {
         let meta = self.read_meta(session_id)?;
         let created_at = iso_to_ms(&meta.created_at);
         let conv = self.get_conversation(session_id)?;
@@ -377,7 +389,10 @@ fn ms_to_iso(secs: i64, ms: i64) -> String {
     let h = time_of_day / 3600;
     let m = (time_of_day % 3600) / 60;
     let s = time_of_day % 60;
-    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}000000Z", year, month, day, h, m, s, ms)
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}000000Z",
+        year, month, day, h, m, s, ms
+    )
 }
 
 fn epoch_secs_to_ymd(secs: i64) -> (i64, i64, i64) {

--- a/src/data/kiro_cli.rs
+++ b/src/data/kiro_cli.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::data::SessionSource;
 use crate::error::{KsmError, Result};
-use crate::models::{ConversationData, Session};
+use crate::models::{ConversationData, Session, SourceType};
 
 /// Session source backed by parsing kiro-cli's stderr output.
 ///
@@ -49,6 +49,7 @@ impl KiroCliSource {
                     updated_at: approximate_updated_at,
                     preview: cap[3].to_string(),
                     msg_count,
+                    source_type: SourceType::Legacy,
                 }
             })
             .collect();

--- a/src/data/kiro_database.rs
+++ b/src/data/kiro_database.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::data::SessionSource;
 use crate::error::{KsmError, Result};
-use crate::models::{ConversationData, Session};
+use crate::models::{ConversationData, Session, SourceType};
 
 /// Session source backed by kiro-cli's SQLite database.
 pub struct KiroDatabase {
@@ -69,6 +69,7 @@ impl KiroDatabase {
             updated_at,
             preview,
             msg_count,
+            source_type: SourceType::Legacy,
         }
     }
 

--- a/src/data/ksm_database.rs
+++ b/src/data/ksm_database.rs
@@ -709,6 +709,7 @@ impl KsmDatabase {
                 msg_count: row.get::<_, i64>(5)? as u32,
                 has_compact_tag: row.get::<_, i32>(6)? != 0,
                 message_ids: serde_json::from_str(&message_ids_json).unwrap_or_default(),
+                source_type: Default::default(),
             })
         })?;
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -132,7 +132,8 @@ impl SessionSource for HybridSource {
         &self,
         session_id: &str,
     ) -> Result<(ConversationData, i64)> {
-        self.route(session_id).get_conversation_with_created_at(session_id)
+        self.route(session_id)
+            .get_conversation_with_created_at(session_id)
     }
 
     fn get_message_ids(&self, session_id: &str) -> Result<Vec<String>> {
@@ -148,7 +149,8 @@ impl SessionSource for HybridSource {
     }
 
     fn update_timestamp(&self, session_id: &str, timestamp: i64) -> Result<()> {
-        self.route(session_id).update_timestamp(session_id, timestamp)
+        self.route(session_id)
+            .update_timestamp(session_id, timestamp)
     }
 
     fn delete_session(&self, session_id: &str) -> Result<()> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,19 +1,21 @@
+mod acp;
 mod json_store;
 mod kiro_cli;
 mod kiro_database;
 mod ksm_database;
 
+pub use acp::AcpSource;
 pub use json_store::JsonMetadataStore;
 pub use kiro_cli::KiroCliSource;
 pub use kiro_database::KiroDatabase;
 pub use ksm_database::KsmDatabase;
 
 use crate::error::Result;
-use crate::models::{ConversationData, Session};
+use crate::models::{ConversationData, Session, SourceType};
 
 /// Read/write access to kiro-cli's session data.
 ///
-/// Implementations: `KiroDatabase` (primary), `KiroCliSource` (fallback).
+/// Implementations: `KiroDatabase` (primary), `KiroCliSource` (fallback), `AcpSource`.
 pub trait SessionSource {
     /// List all sessions for the current directory, ordered by updated_at DESC.
     fn list_sessions(&self) -> Result<Vec<Session>>;
@@ -44,14 +46,24 @@ pub trait SessionSource {
 
     /// Delete a session via kiro-cli.
     fn delete_session(&self, session_id: &str) -> Result<()>;
+
+    /// The source type for sessions produced by this source.
+    fn source_type(&self) -> SourceType {
+        SourceType::Legacy
+    }
+
+    /// The source type for a specific session ID (for routing sources like HybridSource).
+    fn session_source_type(&self, _session_id: &str) -> SourceType {
+        self.source_type()
+    }
 }
 
 /// Hybrid session source: tries database first, falls back to CLI parsing.
-///
-/// Replaces the fallback logic from current `kiro.rs` `get_sessions()`.
+/// Also merges in ACP/TUI sessions from ~/.kiro/sessions/cli/.
 pub struct HybridSource {
     database: KiroDatabase,
     cli_fallback: KiroCliSource,
+    acp: AcpSource,
 }
 
 impl Default for HybridSource {
@@ -65,69 +77,85 @@ impl HybridSource {
         HybridSource {
             database: KiroDatabase::new(),
             cli_fallback: KiroCliSource::new(),
+            acp: AcpSource::new(),
+        }
+    }
+
+    /// Determine which source owns a session ID by checking ACP first (file existence),
+    /// then falling back to legacy.
+    fn route(&self, session_id: &str) -> &dyn SessionSource {
+        let home = std::env::var("HOME").unwrap_or_default();
+        let json_path = std::path::PathBuf::from(home)
+            .join(".kiro/sessions/cli")
+            .join(format!("{}.json", session_id));
+        if json_path.exists() {
+            &self.acp
+        } else {
+            &self.database
         }
     }
 }
 
 impl SessionSource for HybridSource {
     fn list_sessions(&self) -> Result<Vec<Session>> {
-        match self.database.list_sessions() {
-            Ok(sessions) => Ok(sessions),
+        let mut sessions = match self.database.list_sessions() {
+            Ok(s) => s,
             Err(e) => {
-                // Use eprintln! (not log::warn!) so users always see the fallback warning
-                // Matches current kiro.rs output exactly
                 eprintln!("⚠ Database access failed: {}", e);
                 eprintln!("⚠ Falling back to CLI parsing...\n");
-                self.cli_fallback.list_sessions()
+                self.cli_fallback.list_sessions()?
             }
+        };
+
+        // Merge ACP sessions
+        if let Ok(acp_sessions) = self.acp.list_sessions() {
+            sessions.extend(acp_sessions);
         }
+
+        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(sessions)
     }
 
     fn list_session_updates(&self) -> Result<Vec<(String, i64)>> {
-        // No fallback - CLI source doesn't support this
-        self.database.list_session_updates()
+        let mut updates = self.database.list_session_updates()?;
+        if let Ok(acp_updates) = self.acp.list_session_updates() {
+            updates.extend(acp_updates);
+        }
+        Ok(updates)
     }
 
     fn get_conversation(&self, session_id: &str) -> Result<ConversationData> {
-        self.database
-            .get_conversation(session_id)
-            .or_else(|_| self.cli_fallback.get_conversation(session_id))
+        self.route(session_id).get_conversation(session_id)
     }
 
     fn get_conversation_with_created_at(
         &self,
         session_id: &str,
     ) -> Result<(ConversationData, i64)> {
-        // No fallback - CLI source doesn't support this
-        self.database.get_conversation_with_created_at(session_id)
+        self.route(session_id).get_conversation_with_created_at(session_id)
     }
 
     fn get_message_ids(&self, session_id: &str) -> Result<Vec<String>> {
-        self.database
-            .get_message_ids(session_id)
-            .or_else(|_| self.cli_fallback.get_message_ids(session_id))
+        self.route(session_id).get_message_ids(session_id)
     }
 
     fn has_compact_tag(&self, session_id: &str) -> Result<bool> {
-        self.database
-            .has_compact_tag(session_id)
-            .or_else(|_| self.cli_fallback.has_compact_tag(session_id))
+        self.route(session_id).has_compact_tag(session_id)
     }
 
     fn get_timestamps(&self, session_id: &str) -> Result<(i64, i64)> {
-        self.database
-            .get_timestamps(session_id)
-            .or_else(|_| self.cli_fallback.get_timestamps(session_id))
+        self.route(session_id).get_timestamps(session_id)
     }
 
     fn update_timestamp(&self, session_id: &str, timestamp: i64) -> Result<()> {
-        self.database
-            .update_timestamp(session_id, timestamp)
-            .or_else(|_| self.cli_fallback.update_timestamp(session_id, timestamp))
+        self.route(session_id).update_timestamp(session_id, timestamp)
     }
 
     fn delete_session(&self, session_id: &str) -> Result<()> {
-        // Both impls call kiro-cli, so delegate to either
-        self.database.delete_session(session_id)
+        self.route(session_id).delete_session(session_id)
+    }
+
+    fn session_source_type(&self, session_id: &str) -> SourceType {
+        self.route(session_id).source_type()
     }
 }

--- a/src/models/cache.rs
+++ b/src/models/cache.rs
@@ -1,4 +1,4 @@
-use crate::models::Session;
+use crate::models::{Session, SourceType};
 use serde::{Deserialize, Serialize};
 
 /// Cached session data for fast list and chain detection operations.
@@ -15,6 +15,8 @@ pub struct CachedSession {
     pub msg_count: u32,
     pub has_compact_tag: bool,
     pub message_ids: Vec<String>,
+    #[serde(default)]
+    pub source_type: SourceType,
 }
 
 impl From<&CachedSession> for Session {
@@ -25,6 +27,7 @@ impl From<&CachedSession> for Session {
             updated_at: c.updated_at,
             preview: c.preview.clone(),
             msg_count: c.msg_count,
+            source_type: c.source_type,
         }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,4 +15,4 @@ pub use conversation::{
     ToolUseContent, ToolUseResultsContent, UserContent, UserMessage,
 };
 pub use metadata::SessionMetadata;
-pub use session::Session;
+pub use session::{Session, SourceType};

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -1,3 +1,11 @@
+/// Whether a session comes from the legacy SQLite database or the ACP file store.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+pub enum SourceType {
+    #[default]
+    Legacy,
+    Acp,
+}
+
 /// A kiro-cli chat session with raw (unformatted) data.
 ///
 /// Timestamps are milliseconds since epoch. Message count is an integer.
@@ -9,4 +17,5 @@ pub struct Session {
     pub updated_at: i64,
     pub preview: String,
     pub msg_count: u32,
+    pub source_type: SourceType,
 }

--- a/src/services/cache.rs
+++ b/src/services/cache.rs
@@ -65,6 +65,7 @@ pub fn sessions(
             msg_count,
             has_compact_tag,
             message_ids,
+            source_type: source.session_source_type(session_id),
         };
 
         cache.insert(session_id.clone(), cached.clone());
@@ -82,6 +83,12 @@ pub fn sessions(
     // 5. Filter to only sessions that exist in Kiro
     let live_ids: HashSet<_> = updates.iter().map(|(id, _)| id.clone()).collect();
     cache.retain(|id, _| live_ids.contains(id));
+
+    // 6. Always refresh source_type from routing (handles stale cache entries
+    //    that predate the source_type field, e.g. after upgrading ksm)
+    for (session_id, cached) in cache.iter_mut() {
+        cached.source_type = source.session_source_type(session_id);
+    }
 
     Ok(cache)
 }


### PR DESCRIPTION
## Summary

Extends `ksm` to discover and display sessions from the ACP source (`~/.kiro/sessions/cli/`), in addition to the existing database-backed sessions. All sessions now show a `v1`/`v2` version marker in `ksm list` to distinguish between the two session types.

## Changes

- **AcpSource**: New data source that reads ACP session file pairs from `~/.kiro/sessions/cli/`, parsing metadata and content from `.json`/`.md` files
- **HybridSource**: Merges ACP sessions with existing database sessions into a unified session list
- **SourceType**: New enum on `Session` and `CachedSession` models to track session origin (`Database` vs `Acp`)
- **Version markers**: `ksm list` now displays `v1`/`v2` markers for all sessions (replaces the previous `[t]` TUI marker)
- **Docs**: Updated `USAGE.md` and `CHANGELOG.md` to reflect new session support and display changes
